### PR TITLE
fix runtime error when installed .net NET Core Runtime v3 only

### DIFF
--- a/src/NoSln.Tool/runtimeconfig.template.json
+++ b/src/NoSln.Tool/runtimeconfig.template.json
@@ -1,0 +1,3 @@
+{
+    "rollForwardOnNoCandidateFx": 2
+}


### PR DESCRIPTION
Scenario is `dotnet nosln` installed as global/local tool with .NET Core Sdk 3.x or in a docker container based on .NET Core Sdk 3.x

By default the tool expect an installed  .NET Core Runtime >= 2.1 and < 3
The .NET Core Sdk 3.x doesnt contains the runtime 2.1.x, so fails at runtime with

```
It was not possible to find any compatible framework version
The specified framework 'Microsoft.NETCore.App', version '2.1.0' was not found.
  - The following frameworks were found:
      3.0.0 at [/usr/share/dotnet/shared/Microsoft.NETCore.App]
```

Because sdk and runtimes can be installed side by side, doesnt happen if the developer has a .net core sdk 2.1/2.2 installed (who bundle the 2.x runtime)

The issue can be repro'ed with the following dockerfile

```dockerfile
FROM mcr.microsoft.com/dotnet/core/sdk:3.0.100
WORKDIR /app

RUN dotnet new tool-manifest

RUN dotnet tool install --local dotnet-nosln --version 0.6.1 

RUN dotnet nosln --version
```


This fix allow to run with any .net core runtime >= 2.1 so is compatible with any .NET Core Sdk >= 2.1
