### PR TITLE
Generate solution files in SLNX format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -331,5 +331,5 @@ ASALocalRun/
 
 .store/
 /tools/
-*.sln
+*.slnx
 .ionide/

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
     <!-- NuGet metadata -->
     <Authors>Eirik Tsarpalis</Authors>
     <Copyright>2019</Copyright>
-    <PackageTags>dotnet;cli;solutions;sln</PackageTags>
+    <PackageTags>dotnet;cli;solutions;slnx</PackageTags>
     <PackageProjectUrl>https://github.com/eiriktsarpalis/nosln</PackageProjectUrl>
     <RepositoryUrl>https://github.com/eiriktsarpalis/nosln</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,6 @@
     <PackageVersion Include="FSharp.Core" Version="10.1.302" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="MinVer" Version="7.0.0" />
-    <PackageVersion Include="TypeShape" Version="10.0.0" />
     <PackageVersion Include="Unquote" Version="7.0.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ DOCKER_IMAGE_LABEL ?= docker-nosln-build
 DOCKER_CONTAINER_NAME ?= docker-nosln-build-container
 
 clean:
-	dotnet clean -c $(CONFIGURATION) $(NETTOOL_PROJECT) && rm -rf $(TOOL_PATH) && rm -rf $(ARTIFACT_PATH) && rm -rf *.sln
+	dotnet clean -c $(CONFIGURATION) $(NETTOOL_PROJECT) && rm -rf $(TOOL_PATH) && rm -rf $(ARTIFACT_PATH) && rm -rf *.slnx
 
 minver: clean
 	dotnet tool restore
@@ -28,12 +28,12 @@ build: minver
 	dotnet tool install --add-source $(ARTIFACT_PATH) --tool-path $(TOOL_PATH) --version `dotnet minver -v e` dotnet-nosln
 
 test: build
-	dotnet nosln -D -o nosln.sln
-	dotnet build nosln.sln -c $(CONFIGURATION)
-	dotnet test nosln.sln -c $(CONFIGURATION) --no-build
-	dotnet nosln -D src/ -o $(ARTIFACT_PATH)/src.sln
-	dotnet nosln -D examples/ -o $(ARTIFACT_PATH)/examples.sln
-	dotnet nosln -DFT -I 'tests/**/*' -o $(ARTIFACT_PATH)/tests.sln
+	dotnet nosln -D -o nosln.slnx
+	dotnet build nosln.slnx -c $(CONFIGURATION)
+	dotnet test nosln.slnx -c $(CONFIGURATION) --no-build
+	dotnet nosln -D src/ -o $(ARTIFACT_PATH)/src.slnx
+	dotnet nosln -D examples/ -o $(ARTIFACT_PATH)/examples.slnx
+	dotnet nosln -DFT -I 'tests/**/*' -o $(ARTIFACT_PATH)/tests.slnx
 
 install: build
 	dotnet tool update --add-source $(ARTIFACT_PATH) -g dotnet-nosln --version `dotnet minver -v e`

--- a/README.md
+++ b/README.md
@@ -1,32 +1,35 @@
 # dotnet-nosln [![CI](https://github.com/eiriktsarpalis/nosln/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/eiriktsarpalis/nosln/actions/workflows/ci.yml) [![NuGet](https://img.shields.io/nuget/vpre/dotnet-nosln.svg)](https://www.nuget.org/packages/dotnet-nosln/) [![license](https://img.shields.io/github/license/eiriktsarpalis/nosln.svg)](License.md)
 
-dotnet-nosln is a cli tool that generates solution files. 
-Designed to minimize the awkwardness of solution files, 
-nosln treats them as disposable, auto-generated entities deriving from the file system.
+dotnet-nosln is a CLI tool that generates solution files.
+It treats solutions as disposable, auto-generated files derived from the file system.
 
 To install the tool, use the .NET 10 SDK:
+
 ```
 $ dotnet tool install -g dotnet-nosln
 ```
 
 Then simply navigate to your favorite repo and type
+
 ```
 $ dotnet nosln --start
 ```
-This will will automatically generate a solution file based on the folder structure in your current directory,
-then immediately start Visual Studio using that particular solution file.
+This generates a solution file based on the folder structure in the current directory,
+then starts Visual Studio with that file.
 
 It will also include any solution items that happen to exist in the particular folder hierarchy, respecting any `.gitignore` files that happen to exist in the repo.
 
 Running
-```
-$ dotnet nosln -TF -I '**/*Tests*' -o tests.sln
-```
-will create a solution file containing test projects only.
 
-## Building & Installing
+```
+$ dotnet nosln -TF -I '**/*Tests*' -o tests.slnx
+```
+creates a solution file containing test projects only.
+
+## Building and installing
 
 To install nosln on your machine, just clone the repo and run
+
 ```
 make install
 ```
@@ -35,6 +38,7 @@ The .NET 10 SDK and GNU make are required.
 ## More arguments
 
 Full list of all nosln command line arguments:
+
 ```
 USAGE: dotnet nosln [--help] [--version] [--output <solution file>] [--include-projects <pattern>]
                     [--exclude-projects <pattern>] [--include-files <pattern>] [--exclude-files <pattern>]
@@ -67,7 +71,7 @@ OPTIONS:
     --no-files, -F        Do not include any solution items in the generated solution.
     --no-transitive-projects, -T
                           By default, nosln will include transitive p2p dependencies, even if excluded by a globbing
-                          pattern or outside of the project directory.Enable this flag to avoid expanding to
+                          pattern or outside of the project directory. Enable this flag to avoid expanding to
                           transitive projects.
     --absolute-paths, -a  Use absolute paths in generated solution file. Otherwise contents will be relative to the
                           solution file output folder.

--- a/examples/TestApp.Net461/Program.fs
+++ b/examples/TestApp.Net461/Program.fs
@@ -1,5 +1,4 @@
-﻿open System
-open Argu
+﻿open Argu
 
 type Argument =
     | Echo of string

--- a/examples/TestApp1/Program.fs
+++ b/examples/TestApp1/Program.fs
@@ -1,5 +1,4 @@
-﻿open System
-open Argu
+﻿open Argu
 
 type Argument =
     | Echo of string

--- a/examples/TestApp2/Program.fs
+++ b/examples/TestApp2/Program.fs
@@ -1,5 +1,4 @@
-﻿open System
-open Argu
+﻿open Argu
 
 type Argument =
     | Echo of string

--- a/src/NoSln.Tool/Cli.fs
+++ b/src/NoSln.Tool/Cli.fs
@@ -2,7 +2,6 @@ module NoSln.Cli
 
 open System
 open System.IO
-open System.Runtime.InteropServices
 open System.Text.RegularExpressions
 open Fake.IO.FileSystemOperators
 open Argu
@@ -49,7 +48,7 @@ with
             | No_Files ->
                 "Do not include any solution items in the generated solution."
             | No_Transitive_Projects ->
-                "By default, nosln will include transitive p2p dependencies, even if excluded by a globbing pattern or outside of the project directory." +
+                "By default, nosln will include transitive p2p dependencies, even if excluded by a globbing pattern or outside of the project directory. " +
                 "Enable this flag to avoid expanding to transitive projects."
             | Absolute_Paths ->
                 "Use absolute paths in generated solution file. Otherwise contents will be relative to the solution file output folder."
@@ -111,13 +110,13 @@ let processArguments (results : ParseResults<Argument>) =
             let fileName = 
                 let slnIdentifier = Path.GetFileName baseDirectory // get filename of directory
                 let randomSuffix = Path.GetRandomFileName() |> Path.GetFileNameWithoutExtension
-                $"{slnIdentifier}-{randomSuffix}.sln"
+                $"{slnIdentifier}-{randomSuffix}.slnx"
 
             Path.GetTempPath() @@ fileName
         else
             match results.TryGetResult <@ Output @> with
             | Some o -> Path.getFullPathXPlat o
-            | None -> baseDirectory @@ Path.GetFileName baseDirectory + ".sln"
+            | None -> baseDirectory @@ Path.GetFileName baseDirectory + ".slnx"
 
     GenerateSln {
         baseDirectory = baseDirectory
@@ -126,9 +125,7 @@ let processArguments (results : ParseResults<Argument>) =
         fileIncludes = fileIncludes
         fileExcludes = fileExcludes
         gitIgnoreFile = gitIgnoreFile
-        
         targetSolutionFile = targetSln
-        targetSolutionDir = Path.GetDirectoryName targetSln
 
         noFiles = noFiles || flattenProjects
         noTransitiveProjects = noTransitiveProjects

--- a/src/NoSln.Tool/Configuration.fs
+++ b/src/NoSln.Tool/Configuration.fs
@@ -4,7 +4,6 @@ type Configuration =
     {
         baseDirectory : string
         targetSolutionFile : string
-        targetSolutionDir : string
 
         projectIncludes : string list
         projectExcludes : string list

--- a/src/NoSln.Tool/Globbing.fs
+++ b/src/NoSln.Tool/Globbing.fs
@@ -46,8 +46,8 @@ let mkSolution (config : Configuration) : Solution =
                   Includes = match config.fileIncludes with [] -> ["**/*"] | es -> es
                   Excludes = excludedPatterns @ config.fileExcludes @ projectFileExcludes }
 
-            let gitIgnorePatterns = 
-                match GitIgnore.tryFindGitIgnoreFile config.baseDirectory with
+            let gitIgnorePatterns =
+                match config.gitIgnoreFile with
                 | None -> None
                 | Some gitIgnoreFile -> GitIgnore.parse gitIgnoreFile |> Some
 

--- a/src/NoSln.Tool/Main.fs
+++ b/src/NoSln.Tool/Main.fs
@@ -1,7 +1,5 @@
 ﻿module NoSln.Main
 
-open System
-
 [<EntryPoint>]
 let main (argv:string[]) =
     let parser = Cli.mkParser()

--- a/src/NoSln.Tool/Program.fs
+++ b/src/NoSln.Tool/Program.fs
@@ -1,8 +1,0 @@
-﻿// Learn more about F# at http://fsharp.org
-
-open System
-
-[<EntryPoint>]
-let main argv =
-    printfn "Hello World from F#!"
-    0 // return an integer exit code

--- a/src/NoSln.Tool/Utils.fs
+++ b/src/NoSln.Tool/Utils.fs
@@ -76,7 +76,7 @@ module Process =
             let _ = Process.Start psi
             ()
 
-        | env -> raise <| NotImplementedException(sprintf "execution of sln files not yet implemented in %O environments" env)
+        | env -> raise <| NotImplementedException(sprintf "execution of solution files not yet implemented in %O environments" env)
 
 type ColoredProcessExiter() =
     interface IExiter with

--- a/src/NoSln/Builder.fs
+++ b/src/NoSln/Builder.fs
@@ -1,29 +1,12 @@
 ﻿module internal NoSln.Builder
 
-// Simple tool for generating Solution files out of a list of projects.
+// Simple tool for generating solution files out of a list of projects.
 
 open System
 open System.Collections.Generic
 open System.IO
 open System.Xml.Linq
 open NoSln
-
-[<AutoOpen>]
-module private ProjectTypeGuids =
-
-    //----------------------------------------------------------------------
-    let directoryGuid    = Guid.Parse "2150E333-8FDC-42A3-9474-1A3956D46DE8"
-    //----------------------------------------------------------------------
-    let csProjGuid       = Guid.Parse "9A19103F-16F7-4668-BE54-9A1E7A4F7556"
-    let vbProjGuid       = Guid.Parse "778DAE3C-4631-46EA-AA77-85C1314464D9"
-    let fsProjGuid       = Guid.Parse "6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705"
-    //----------------------------------------------------------------------
-    let csProjGuidLegacy = Guid.Parse "FAE04EC0-301F-11D3-BF4B-00C04F79EFBC"
-    let vbProjGuidLegacy = Guid.Parse "F184B08F-C81C-45F6-A57F-5ABD9991F28F"
-    let fsProjGuidLegacy = Guid.Parse "F2A71F9B-5D33-465A-A702-920D77279786"
-
-
-//----------------------
 
 type SolutionConfiguration =
     {
@@ -40,7 +23,7 @@ type SolutionConfiguration =
 
 /// creates a solution file contained in supplied directory
 let mkSolutionFileForDirectory (baseDirectory : string) =
-    let fileName = Path.GetFileName baseDirectory + ".sln"
+    let fileName = Path.GetFileName baseDirectory + ".slnx"
     Path.Combine(baseDirectory, fileName)
 
 /// Generates a random solution file in the system temp directory
@@ -48,7 +31,7 @@ let mkTempSolutionfile (baseDirectory : string) =
     let tempPath = Path.GetTempPath()
     let slnIdentifier = Path.GetFileName baseDirectory // get filename of directory
     let randomSuffix = Path.GetRandomFileName() |> Path.GetFileNameWithoutExtension
-    let filename = $"{slnIdentifier}-{randomSuffix}.sln"
+    let filename = $"{slnIdentifier}-{randomSuffix}.slnx"
     Path.Combine(tempPath, filename)
 
 /// gets the file path to be used within the solution file
@@ -57,8 +40,8 @@ let getPathRelativeToSolutionFile (config : SolutionConfiguration) (fullPath : s
         if config.useAbsolutePaths then fullPath
         else Path.getRelativePath (Path.GetDirectoryName config.targetSolutionFile) fullPath
 
-    // Paths in solution file always separated by backslash, regardless of OS
-    path.Replace('/', '\\')
+    // Paths in solution files always use forward slashes, regardless of OS.
+    path.Replace('\\', '/')
 
 /// extracts the solution path (i.e. location of item within nested logical folders) from a given filesystem full path
 let getLogicalPath (config : SolutionConfiguration) (fullPath : string) =
@@ -72,19 +55,6 @@ let getLogicalPath (config : SolutionConfiguration) (fullPath : string) =
         // replace with something acceptable
         path |> Seq.map (function ".." -> "[..]" | p -> p) |> Seq.toList
 
-
-// By no means complete c.f. https://www.codeproject.com/Reference/720512/List-of-Visual-Studio-Project-Type-GUIDs
-let getProjectTypeGuid (fullPath : string) (contents : XDocument) =
-    let isLegacyProject = 
-        contents.Root.Attributes() 
-        |> Seq.exists (fun attr -> attr.Name.LocalName = "Sdk")
-        |> not
-
-    match Path.GetExtension(fullPath).ToLower() with
-    | ".fsproj" -> if isLegacyProject then fsProjGuidLegacy else fsProjGuid
-    | ".csproj" -> if isLegacyProject then csProjGuidLegacy else csProjGuid
-    | ".vbproj" -> if isLegacyProject then vbProjGuidLegacy else vbProjGuid
-    | _ -> csProjGuidLegacy
 
 /// creates a new project node from project file path
 let mkProject (config : SolutionConfiguration) (fullPath : string) : SolutionProject =
@@ -111,11 +81,7 @@ let mkProject (config : SolutionConfiguration) (fullPath : string) : SolutionPro
             else throw NoSlnException "project %A contains p2p reference %A which was not found" fullPath r)
         |> Seq.toList
 
-    let projectTypeGuid = getProjectTypeGuid fullPath xdocument
-
-    { id = Guid.NewGuid() ; 
-      projectTypeGuid = projectTypeGuid ; 
-      p2pReferences = p2pReferences ;
+    { p2pReferences = p2pReferences ;
       name = name ; 
       relativePath = path ; 
       logicalPath = logicalPath ; 
@@ -151,7 +117,7 @@ let mkFile (config : SolutionConfiguration) (fullPath : string) : SolutionFile =
         | [] -> ["Solution Items"] // files cannot live in solution root
         | p -> p
 
-    { id = path ; relativePath = path ; logicalPath = logicalPath ; fullPath = fullPath }
+    { relativePath = path ; logicalPath = logicalPath ; fullPath = fullPath }
 
 let mkFiles (config : SolutionConfiguration) =
     config.files |> List.map (mkFile config)
@@ -171,20 +137,17 @@ with
     /// Maps to immutable folder structure
     member folderB.ToFolder() : SolutionFolder =
         let rec aux (folderB : FolderBuilder) : SolutionFolder =
-            let id = Guid.NewGuid()
             let projects = folderB.projects |> Seq.sortBy _.name |> Seq.toList
-            let files = folderB.files |> Seq.sortBy _.id |> Seq.toList
+            let files = folderB.files |> Seq.sortBy _.relativePath |> Seq.toList
             let folders = 
                 folderB.folders.Values
                 |> Seq.map aux
                 |> Seq.sortBy _.name
                 |> Seq.toList
             {
-                id = id
                 name = folderB.name
                 folders = folders
                 projects = projects
-                projectTypeGuid = ProjectTypeGuids.directoryGuid
                 files = files
             }
 
@@ -221,7 +184,6 @@ let mkSolution (config : SolutionConfiguration) =
     assert rootFolder.files.IsEmpty
 
     {
-        id = rootFolder.id
         targetSolutionFile = config.targetSolutionFile
         projects = rootFolder.projects
         folders = rootFolder.folders

--- a/src/NoSln/Formatter.fs
+++ b/src/NoSln/Formatter.fs
@@ -1,122 +1,50 @@
-﻿module internal rec NoSln.Formatter
+﻿module internal NoSln.Formatter
 
 open System
+open System.Xml.Linq
 
-/// Formats a solution tree into a solution file text
-let formatSolution solution =
-    formatSolutionFileLines solution
-    |> String.concat Environment.NewLine
+let private addAttribute name value (element : XElement) =
+    element.Add(XAttribute(XName.Get name, value))
+    element
 
-/// writes solution object to its target file
+let private formatProject (project : SolutionProject) =
+    XElement(XName.Get "Project")
+    |> addAttribute "Path" project.relativePath
+
+let private formatFile (file : SolutionFile) =
+    XElement(XName.Get "File")
+    |> addAttribute "Path" file.relativePath
+
+let rec private formatFolder parentPath (folder : SolutionFolder) = seq {
+    let path = parentPath @ [folder.name]
+    let folderName = "/" + String.concat "/" path + "/"
+    let element =
+        XElement(XName.Get "Folder")
+        |> addAttribute "Name" folderName
+
+    for file in folder.files do element.Add(formatFile file)
+    for project in folder.projects do element.Add(formatProject project)
+
+    yield element
+
+    for child in folder.folders do
+        yield! formatFolder path child
+}
+
+/// Formats a solution tree into a solution file text.
+let formatSolution (solution : Solution) =
+    let element = XElement(XName.Get "Solution")
+
+    for folder in solution.folders do
+        for folderElement in formatFolder [] folder do
+            element.Add folderElement
+
+    for project in solution.projects do
+        element.Add(formatProject project)
+
+    element.ToString() + Environment.NewLine
+
+/// Writes a solution object to its target file.
 let writeSolutionFile solution =
     let contents = formatSolution solution
     System.IO.File.WriteAllText(path = solution.targetSolutionFile, contents = contents)
-
-let private formatSolutionFileLines (solution : Solution) = seq {
-    // flatten the solution structure into a list of guid relations
-    let projects = ResizeArray<SolutionProject>()
-    let folders = ResizeArray<SolutionFolder>()
-    let nestedNodes = ResizeArray<Guid * Guid>()
-
-    let rec visitProject (project : SolutionProject) =
-        projects.Add project
-
-    and visitFolder (folder : SolutionFolder) =
-        folders.Add folder
-        for proj in folder.projects do 
-            nestedNodes.Add(proj.id, folder.id)
-            visitProject proj
-
-        for f in folder.folders do 
-            nestedNodes.Add(f.id, folder.id)
-            visitFolder f
-
-    for proj in solution.projects do visitProject proj
-    for folder in solution.folders do visitFolder folder
-
-    // begin formatting
-    let fmtGuid (g:Guid) = g.ToString().ToUpper()
-
-    yield "Microsoft Visual Studio Solution File, Format Version 12.00"
-    yield "# Visual Studio 15"
-    yield "VisualStudioVersion = 15.0.27428.2002"
-    yield "MinimumVisualStudioVersion = 10.0.40219.1"
-
-    let fmtProject (project : SolutionProject) = seq {
-        yield sprintf """Project("{%s}") = "%s", "%s", "{%s}" """
-                    (fmtGuid project.projectTypeGuid) project.name project.relativePath (fmtGuid project.id)
-
-        yield "EndProject"
-    }
-
-    let fmtFolder (folder : SolutionFolder) = seq {
-        yield sprintf """Project("{%s}") = "%s", "%s", "{%s}" """
-                (fmtGuid folder.projectTypeGuid) folder.name folder.name (fmtGuid folder.id)
-
-        match folder.files with
-        | [] -> ()
-        | files ->
-            yield "\tProjectSection(SolutionItems) = preProject"
-            for file in files |> Seq.sortBy _.id.ToLowerInvariant() do yield sprintf "\t\t%s = %s" file.id file.relativePath
-            yield "\tEndProjectSection"
-
-        yield "EndProject"
-    }
-
-    // Need to topologically sort when formatting projects in solution,
-    // otherwise we get this https://github.com/dotnet/cli/issues/10484
-    for proj in getTopologicalOrdering projects do yield! fmtProject proj
-    for folder in folders do yield! fmtFolder folder
-
-    // Global Section
-    yield "Global"
-
-    yield "\tGlobalSection(SolutionConfigurationPlatforms) = preSolution"
-    yield "\t\tDebug|Any CPU = Debug|Any CPU"
-    yield "\t\tRelease|Any CPU = Release|Any CPU"
-    yield "\tEndGlobalSection"
-
-    yield "\tGlobalSection(ProjectConfigurationPlatforms) = postSolution"
-    for proj in projects do 
-        let fmt config platform cfg = 
-            sprintf "\t\t{%s}.%s|%s.%s = %s|%s"
-                (fmtGuid proj.id) config platform cfg config platform
-
-        // TODO: detect nonstandard project configurations
-        yield fmt "Debug" "Any CPU" "ActiveCfg"
-        yield fmt "Debug" "Any CPU" "Build.0"
-        yield fmt "Release" "Any CPU" "ActiveCfg"
-        yield fmt "Release" "Any CPU" "Build.0"
-    yield "\tEndGlobalSection"
-
-    yield "\tGlobalSection(SolutionProperties) = preSolution"
-    yield "\t\tHideSolutionNode = FALSE"
-    yield "\tEndGlobalSection"
-
-    if nestedNodes.Count > 0 then
-        yield "\tGlobalSection(NestedProjects) = preSolution"
-        for child,parent in nestedNodes do yield sprintf "\t\t{%s} = {%s}" (fmtGuid child) (fmtGuid parent)
-        yield "\tEndGlobalSection"
-
-    yield "\tGlobalSection(ExtensibilityGlobals) = postSolution"
-    yield sprintf "\t\tSolutionGuid = {%s}"(fmtGuid solution.id)
-    yield "\tEndGlobalSection"
-
-    yield "EndGlobal"
-    yield ""
-}
-
-/// calculates topological ordering of supplied project files
-let private getTopologicalOrdering (projects : seq<SolutionProject>) =
-    let index = projects |> Seq.map (fun p -> p.fullPath, p) |> dict
-
-    let graph =
-        index.Values
-        |> Seq.map (fun p -> 
-            // prune references that point to nodes outside of the current project set
-            let trimmedEdges = p.p2pReferences |> Seq.filter index.ContainsKey |> ResizeArray
-            p.fullPath, trimmedEdges)
-
-    match Graph.tryGetTopologicalSorting graph with
-    | Some sorted -> sorted |> Seq.map (fun k -> index.[k]) |> Seq.toList
-    | None -> Seq.toList projects // silently ignore cyclic dependencies

--- a/src/NoSln/NoSln.fs
+++ b/src/NoSln/NoSln.fs
@@ -24,7 +24,7 @@ type NoSln =
     /// <summary>
     ///     Builds a solution object from a collection of project and file paths.
     /// </summary>
-    /// <param name="baseDirectory">Base directory for the generated solution. Sln folder structure will reflect paths relative to that base directory. Defaults to current directory.</param>
+    /// <param name="baseDirectory">Base directory for the generated solution. The solution folder structure will reflect paths relative to that base directory. Defaults to current directory.</param>
     /// <param name="projects">List of project files to be included in the solution as projects.</param>
     /// <param name="files">List of regular files to be included in the solution.</param>
     /// <param name="targetSolutionFile">Target path of the generated solution file. Defaults to a solution file located in the base directory.</param>
@@ -66,7 +66,7 @@ type NoSln =
     /// <summary>
     ///     Writes a solution file from a collection of project and file paths.
     /// </summary>
-    /// <param name="baseDirectory">Base directory for the generated solution. Sln folder structure will reflect paths relative to that base directory. Defaults to current directory.</param>
+    /// <param name="baseDirectory">Base directory for the generated solution. The solution folder structure will reflect paths relative to that base directory. Defaults to current directory.</param>
     /// <param name="projects">List of project files to be included in the solution as projects.</param>
     /// <param name="files">List of regular files to be included in the solution.</param>
     /// <param name="targetSolutionFile">Target path of the generated solution file. Defaults to a solution file located in the base directory.</param>

--- a/src/NoSln/Types.fs
+++ b/src/NoSln/Types.fs
@@ -1,12 +1,8 @@
 ﻿namespace rec NoSln
 
-open System
-
 /// Solution tree representation
 type Solution =
     {
-        /// Solution UUID
-        id : Guid
         /// Root folders in solution
         folders : SolutionFolder list
         /// Root projects in solution
@@ -19,10 +15,6 @@ type Solution =
 /// Solution folder representation
 type SolutionFolder =
     {
-        /// Folder UUID
-        id : Guid
-        /// Project type UUID
-        projectTypeGuid : Guid
         /// Folder name
         name  : string
         /// Folders contained within folder
@@ -36,12 +28,8 @@ type SolutionFolder =
 /// Solution project representation
 type SolutionProject =
     {
-        /// Project UUID
-        id : Guid
         /// Project name
         name : string
-        /// Project type UUID
-        projectTypeGuid : Guid
         /// P2P references of project
         p2pReferences : string list
         /// Fully qualified filesystem path
@@ -55,8 +43,6 @@ type SolutionProject =
 /// Solution file representation
 type SolutionFile =
     {
-        /// File identifier
-        id : string
         /// Fully qualified filesystem path
         fullPath : string
         /// Filesystem path relative to solution file

--- a/src/NoSln/Utils.fs
+++ b/src/NoSln/Utils.fs
@@ -59,34 +59,3 @@ module Dictionary =
         let dict = Dictionary<_,_>()
         for k,v in keyValuePairs do dict.Add(k,v)
         dict
-
-type Map<'k,'v when 'k : comparison> with
-    member m.Keys   = (m :> IDictionary<'k,'v>).Keys
-    member m.Values = (m :> IDictionary<'k,'v>).Values
-
-
-module Graph =
-
-    let tryGetTopologicalSorting (graph : seq<'T * #seq<'T>>) =
-        // straightforward implementation of Kahn's algorithm
-        let state = 
-            graph 
-            |> Seq.map (fun (v,es) -> v, HashSet(es :> seq<_>))
-            |> Dictionary.create
-
-        let sorted = ResizeArray()
-
-        let stripVertex v =
-            state.Remove v |> ignore
-            for es in state.Values do es.Remove v |> ignore
-
-        let rec aux () =
-            if state.Count = 0 then Seq.toList sorted |> Some
-            else
-                match state |> Seq.tryFind (fun kv -> kv.Value.Count = 0) with
-                | None -> None // graph contains cycles, cannot find topological sort
-                | Some (KeyValue(v,_)) ->
-                    stripVertex v
-                    sorted.Add v
-                    aux()
-        aux()

--- a/tests/NoSln.Tests/NoSln.Tests.fsproj
+++ b/tests/NoSln.Tests/NoSln.Tests.fsproj
@@ -12,7 +12,6 @@
   <ItemGroup>
     <PackageReference Include="Fake.IO.FileSystem" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="TypeShape" />
     <PackageReference Include="Unquote" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">

--- a/tests/NoSln.Tests/Tests.fs
+++ b/tests/NoSln.Tests/Tests.fs
@@ -3,7 +3,6 @@
 open System
 open System.IO
 open Xunit
-open TypeShape.Empty
 open Swensen.Unquote.Assertions
 open Fake.IO.FileSystemOperators
 open Fake.IO.Globbing.Operators
@@ -11,39 +10,80 @@ open Fake.IO.Globbing.Operators
 open NoSln
 open NoSln.Tests
 
-let repoDirectory = __SOURCE_DIRECTORY__ @@ ".." @@ ".." |> Path.GetFullPath
+let rec private findRepoDirectory directory =
+    if File.Exists(directory @@ "Directory.Build.props") then directory
+    else
+        match Directory.GetParent directory with
+        | null -> failwith "Could not locate the repository root."
+        | parent -> findRepoDirectory parent.FullName
 
-let allProjects = lazy(!! (repoDirectory @@ "**" @@ "*.??proj") |> Seq.toList)
-let allFiles = lazy(!! (repoDirectory @@ "**" @@ "*") |> Seq.toList)
+let private getRepoDirectory () = findRepoDirectory AppContext.BaseDirectory
+let private getAllProjects repoDirectory = !! (repoDirectory @@ "**" @@ "*.??proj") |> Seq.toList
+let private getAllFiles repoDirectory = !! (repoDirectory @@ "**" @@ "*") |> Seq.toList
 
 [<Fact>]
 let ``Generated solution should place test project in right folder`` () =
-    let sln = NoSln.CreateSolution(baseDirectory = repoDirectory, projects = allProjects.Value)
+    let repoDirectory = getRepoDirectory ()
+    let sln = NoSln.CreateSolution(baseDirectory = repoDirectory, projects = getAllProjects repoDirectory)
 
     sln |> tryFindPath ["tests"; "NoSln.Tests"] =! Some Project
 
 [<Fact>]
 let ``Generated solution should place solution items in right folder`` () =
-    let sln = NoSln.CreateSolution(baseDirectory = repoDirectory, files = allFiles.Value)
+    let repoDirectory = getRepoDirectory ()
+    let sln = NoSln.CreateSolution(baseDirectory = repoDirectory, files = getAllFiles repoDirectory)
 
     sln |> tryFindPath ["Solution Items"; ".gitignore"] =! Some File
 
 [<Fact>]
 let ``Generated solution with flattened structure place test project in right folder`` () =
-    let sln = NoSln.CreateSolution(baseDirectory = repoDirectory, projects = allProjects.Value, flattenSolutionFolders = true)
+    let repoDirectory = getRepoDirectory ()
+    let sln = NoSln.CreateSolution(baseDirectory = repoDirectory, projects = getAllProjects repoDirectory, flattenSolutionFolders = true)
 
     sln |> tryFindPath ["NoSln.Tests"] =! Some Project
 
 [<Fact>]
 let ``Referencing test projects should include transitive dependencies by default`` () =
-    let project = __SOURCE_DIRECTORY__ @@ "NoSln.Tests.fsproj"
-    let sln = NoSln.CreateSolution(baseDirectory = repoDirectory, projects = [project])
+    let repoDirectory = getRepoDirectory ()
+    let testProject = repoDirectory @@ "tests" @@ "NoSln.Tests" @@ "NoSln.Tests.fsproj"
+    let sln = NoSln.CreateSolution(baseDirectory = repoDirectory, projects = [testProject])
 
     sln |> tryFindPath ["src" ; "NoSln.Library"] =! Some Project
 
 [<Fact>]
 let ``Referencing test projects should not include transitive dependencies if disabled`` () =
-    let project = __SOURCE_DIRECTORY__ @@ "NoSln.Tests.fsproj"
-    let sln = NoSln.CreateSolution(baseDirectory = repoDirectory, projects = [project], includeTransitiveP2pReferences = false)
+    let repoDirectory = getRepoDirectory ()
+    let testProject = repoDirectory @@ "tests" @@ "NoSln.Tests" @@ "NoSln.Tests.fsproj"
+    let sln = NoSln.CreateSolution(baseDirectory = repoDirectory, projects = [testProject], includeTransitiveP2pReferences = false)
 
     sln |> tryFindPath ["src" ; "NoSln.Library"] =! None
+
+[<Fact>]
+let ``Generated solution should use XML format`` () =
+    let repoDirectory = getRepoDirectory ()
+    let project = repoDirectory @@ "src" @@ "NoSln" @@ "NoSln.Library.fsproj"
+    let file = repoDirectory @@ "README.md"
+    let solution = NoSln.CreateSolution(baseDirectory = repoDirectory, projects = [project], files = [file])
+
+    let expected =
+        String.concat Environment.NewLine
+            [ "<Solution>"
+              "  <Folder Name=\"/Solution Items/\">"
+              "    <File Path=\"README.md\" />"
+              "  </Folder>"
+              "  <Folder Name=\"/src/\">"
+              "    <Project Path=\"src/NoSln/NoSln.Library.fsproj\" />"
+              "  </Folder>"
+              "</Solution>"
+              "" ]
+
+    solution.Format() =! expected
+
+[<Fact>]
+let ``Generated solution paths should use the .slnx extension`` () =
+    let repoDirectory = getRepoDirectory ()
+    let solution = NoSln.CreateSolution(baseDirectory = repoDirectory)
+    let tempSolution = NoSln.CreateSolution(baseDirectory = repoDirectory, useTempSolutionFile = true)
+
+    Path.GetExtension solution.targetSolutionFile =! ".slnx"
+    Path.GetExtension tempSolution.targetSolutionFile =! ".slnx"

--- a/tests/NoSln.Tests/Utils.fs
+++ b/tests/NoSln.Tests/Utils.fs
@@ -1,6 +1,7 @@
 ﻿[<AutoOpen>]
 module NoSln.Tests.Utils
 
+open System.IO
 open NoSln
 
 type Node =
@@ -19,7 +20,7 @@ let tryFindPath (path : string list) (solution : Solution) =
                 match projects |> Seq.filter (fun p -> p.name = item) |> Seq.tryHead with
                 | Some p -> Some Project
                 | None ->
-                    match files |> Seq.filter (fun f -> f.id = item) |> Seq.tryHead with
+                    match files |> Seq.filter (fun f -> Path.GetFileName f.fullPath = item) |> Seq.tryHead with
                     | Some f -> Some File
                     | None -> None
 


### PR DESCRIPTION
Replace legacy `.sln` serialization with canonical `.slnx` XML and use `.slnx` for generated, temporary, build, and documented solution paths.

The model no longer carries legacy solution, project, folder, or project-type GUIDs. This also removes obsolete graph helpers, an orphaned tool entry point, and the unused `TypeShape` dependency. `--no-git-ignore` now correctly uses the CLI configuration.

Validated with .NET SDK 10.0.302: all seven tests pass, generated solution files are accepted by `dotnet sln ... list`, and the packed tool installs and generates the expected root, source, example, and test solutions.

Versioning remains MinVer tag-driven; the release should be tagged `1.0.0`.